### PR TITLE
Add dependency type `framework`

### DIFF
--- a/docs/deps.zig.md
+++ b/docs/deps.zig.md
@@ -48,3 +48,7 @@ An ensembled list of all the `c_source_files` lists.
 ### `system_libs`
 - Type: `[][]const u8`
 An ensembled list of all the `system_libs` lists.
+
+### `frameworks`
+- Type: `[][]const u8`
+An ensembled list of all the `frameworks` lists.

--- a/docs/zig.mod.md
+++ b/docs/zig.mod.md
@@ -51,6 +51,7 @@ This is the base attribute used to reference external code for use in your proje
 
 The available `type`s are:
 - `system_lib`
+- `framework`
 - `git`
 - `hg`
 - `http`
@@ -65,6 +66,8 @@ This attribute is used to reference the `type`/`path` combo by a specific revisi
 
 Version types available to each Dep type:
 - `system_lib`
+    - Not affected by `version`.
+- `framework`
     - Not affected by `version`.
 - `git`
     - `commit`

--- a/src/cmd/fetch.zig
+++ b/src/cmd/fetch.zig
@@ -11,7 +11,7 @@ const common = @import("./../common.zig");
 
 pub fn execute(args: [][]u8) !void {
     //
-    const dir = try fs.path.join(gpa, &.{ ".zigmod", "deps" });
+    const dir = try fs.path.join(gpa, &.{".zigmod", "deps"});
 
     const top_module = try common.collect_deps_deep(dir, "zig.mod", .{
         .log = true,
@@ -134,7 +134,7 @@ fn print_paths(w: fs.File.Writer, list: []u.Module) !void {
             try w.print("    \"\",\n", .{});
         } else {
             const s = std.fs.path.sep_str;
-            try w.print("    \"{}{}{}\",\n", .{ std.zig.fmtEscapes(s), std.zig.fmtEscapes(mod.clean_path), std.zig.fmtEscapes(s) });
+            try w.print("    \"{}{}{}\",\n", .{std.zig.fmtEscapes(s), std.zig.fmtEscapes(mod.clean_path), std.zig.fmtEscapes(s)});
         }
     }
 }
@@ -156,12 +156,13 @@ fn print_deps(w: fs.File.Writer, dir: []const u8, m: u.Module, tabs: i32, array:
             continue;
         }
         if (!array) {
-            try w.print("    pub const {s} = packages[{}];\n", .{ std.mem.replaceOwned(u8, gpa, d.name, "-", "_"), i });
-        } else {
+            try w.print("    pub const {s} = packages[{}];\n", .{std.mem.replaceOwned(u8, gpa, d.name, "-", "_"), i});
+        }
+        else {
             try w.print("    package_data._{s},\n", .{d.id});
         }
     }
-    try w.print("{s}", .{try u.concat(&.{ r, "}" })});
+    try w.print("{s}", .{try u.concat(&.{r,"}"})});
 }
 
 fn print_incl_dirs_to(w: fs.File.Writer, list: []u.Module) !void {
@@ -202,11 +203,12 @@ fn print_csrc_flags_to(w: fs.File.Writer, list: []u.Module) !void {
         if (mod.c_source_flags.len == 0 and mod.c_source_files.len == 0) {
             continue;
         }
-        try w.print("    pub const @\"{s}\" = {s}", .{ mod.id, "&.{" });
+        try w.print("    pub const @\"{s}\" = {s}", .{mod.id, "&.{"});
         for (mod.c_source_flags) |it| {
             try w.print("\"{}\",", .{std.zig.fmtEscapes(it)});
         }
         try w.print("{s};\n", .{"}"});
+
     }
 }
 

--- a/src/common.zig
+++ b/src/common.zig
@@ -80,7 +80,8 @@ fn get_moddir(basedir: []const u8, d: u.Dep, parent_name: []const u8, comptime o
             return "";
         },
         .framework => {
-            u.assert(std.Target.current.isDarwin(), "a dependency is attempting to link to the framework {s}, which is only possible under Darwin", .{d.name});
+            const ident = if (d.name.len != 0) d.name else d.path;
+            u.assert(std.Target.current.isDarwin(), "a dependency is attempting to link to the framework {s}, which is only possible under Darwin", .{ident});
             return "";
         },
         .git => {

--- a/src/common.zig
+++ b/src/common.zig
@@ -75,8 +75,12 @@ fn get_moddir(basedir: []const u8, d: u.Dep, parent_name: []const u8, comptime o
     const tempdir = try fs.path.join(gpa, &.{basedir, "temp"});
     if (options.log) { u.print("fetch: {s}: {s}: {s}", .{parent_name, @tagName(d.type), d.path}); }
     switch (d.type) {
-        .system_lib, .framework => {
+        .system_lib => {
             // no op
+            return "";
+        },
+        .framework => {
+            u.assert(std.Target.current.isDarwin(), "a dependency is attempting to link to the framework {s}, which is only possible under Darwin", .{d.name});
             return "";
         },
         .git => {

--- a/src/util/dep_type.zig
+++ b/src/util/dep_type.zig
@@ -8,9 +8,10 @@ const u = @import("./index.zig");
 
 pub const DepType = enum {
     system_lib, // std.build.LibExeObjStep.linkSystemLibrary
-    git,        // https://git-scm.com/
-    hg,         // https://www.mercurial-scm.org/
-    http,       // https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+    framework, // std.build.LibExeObjStep.linkFramework
+    git, // https://git-scm.com/
+    hg, // https://www.mercurial-scm.org/
+    http, // https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
     // svn,        // https://subversion.apache.org/
     // fossil,     // https://fossil-scm.org/
     // cvs,        // https://nongnu.org/cvs/
@@ -31,27 +32,22 @@ pub const DepType = enum {
 
     pub fn pull(self: DepType, rpath: []const u8, dpath: []const u8) !void {
         switch (self) {
-            .system_lib => {},
+            .system_lib, .framework => {},
             .git => {
-                _ = try u.run_cmd(null, &.{"git", "clone", "--recurse-submodules", rpath, dpath});
+                _ = try u.run_cmd(null, &.{ "git", "clone", "--recurse-submodules", rpath, dpath });
             },
             .hg => {
-                _ = try u.run_cmd(null, &.{"hg", "clone", rpath, dpath});
+                _ = try u.run_cmd(null, &.{ "hg", "clone", rpath, dpath });
             },
             .http => {
                 try u.mkdir_all(dpath);
-                _ = try u.run_cmd(dpath, &.{"wget", rpath});
-                const f = rpath[std.mem.lastIndexOf(u8, rpath, "/").?+1..];
+                _ = try u.run_cmd(dpath, &.{ "wget", rpath });
+                const f = rpath[std.mem.lastIndexOf(u8, rpath, "/").? + 1 ..];
                 if (std.mem.endsWith(u8, f, ".zip")) {
-                    _ = try u.run_cmd(dpath, &.{"unzip", f, "-d", "."});
+                    _ = try u.run_cmd(dpath, &.{ "unzip", f, "-d", "." });
                 }
-                if (
-                    std.mem.endsWith(u8, f, ".tar")
-                    or std.mem.endsWith(u8, f, ".tar.gz")
-                    or std.mem.endsWith(u8, f, ".tar.xz")
-                    or std.mem.endsWith(u8, f, ".tar.zst")
-                ) {
-                    _ = try u.run_cmd(dpath, &.{"tar", "-xf", f, "-C", "."});
+                if (std.mem.endsWith(u8, f, ".tar") or std.mem.endsWith(u8, f, ".tar.gz") or std.mem.endsWith(u8, f, ".tar.xz") or std.mem.endsWith(u8, f, ".tar.zst")) {
+                    _ = try u.run_cmd(dpath, &.{ "tar", "-xf", f, "-C", "." });
                 }
             },
         }
@@ -59,13 +55,13 @@ pub const DepType = enum {
 
     pub fn update(self: DepType, dpath: []const u8, rpath: []const u8) !void {
         switch (self) {
-            .system_lib => {},
+            .system_lib, .framework => {},
             .git => {
-                _ = try u.run_cmd(dpath, &.{"git", "fetch"});
-                _ = try u.run_cmd(dpath, &.{"git", "pull"});
+                _ = try u.run_cmd(dpath, &.{ "git", "fetch" });
+                _ = try u.run_cmd(dpath, &.{ "git", "pull" });
             },
             .hg => {
-                _ = try u.run_cmd(dpath, &.{"hg", "pull"});
+                _ = try u.run_cmd(dpath, &.{ "hg", "pull" });
             },
             .http => {
                 //

--- a/src/util/dep_type.zig
+++ b/src/util/dep_type.zig
@@ -8,10 +8,10 @@ const u = @import("./index.zig");
 
 pub const DepType = enum {
     system_lib, // std.build.LibExeObjStep.linkSystemLibrary
-    framework, // std.build.LibExeObjStep.linkFramework
-    git, // https://git-scm.com/
-    hg, // https://www.mercurial-scm.org/
-    http, // https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+    framework,  // std.build.LibExeObjStep.linkFramework
+    git,        // https://git-scm.com/
+    hg,         // https://www.mercurial-scm.org/
+    http,       // https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
     // svn,        // https://subversion.apache.org/
     // fossil,     // https://fossil-scm.org/
     // cvs,        // https://nongnu.org/cvs/
@@ -34,20 +34,25 @@ pub const DepType = enum {
         switch (self) {
             .system_lib, .framework => {},
             .git => {
-                _ = try u.run_cmd(null, &.{ "git", "clone", "--recurse-submodules", rpath, dpath });
+                _ = try u.run_cmd(null, &.{"git", "clone", "--recurse-submodules", rpath, dpath});
             },
             .hg => {
-                _ = try u.run_cmd(null, &.{ "hg", "clone", rpath, dpath });
+                _ = try u.run_cmd(null, &.{"hg", "clone", rpath, dpath});
             },
             .http => {
                 try u.mkdir_all(dpath);
-                _ = try u.run_cmd(dpath, &.{ "wget", rpath });
-                const f = rpath[std.mem.lastIndexOf(u8, rpath, "/").? + 1 ..];
+                _ = try u.run_cmd(dpath, &.{"wget", rpath});
+                const f = rpath[std.mem.lastIndexOf(u8, rpath, "/").?+1..];
                 if (std.mem.endsWith(u8, f, ".zip")) {
-                    _ = try u.run_cmd(dpath, &.{ "unzip", f, "-d", "." });
+                    _ = try u.run_cmd(dpath, &.{"unzip", f, "-d", "."});
                 }
-                if (std.mem.endsWith(u8, f, ".tar") or std.mem.endsWith(u8, f, ".tar.gz") or std.mem.endsWith(u8, f, ".tar.xz") or std.mem.endsWith(u8, f, ".tar.zst")) {
-                    _ = try u.run_cmd(dpath, &.{ "tar", "-xf", f, "-C", "." });
+                if (
+                    std.mem.endsWith(u8, f, ".tar")
+                    or std.mem.endsWith(u8, f, ".tar.gz")
+                    or std.mem.endsWith(u8, f, ".tar.xz")
+                    or std.mem.endsWith(u8, f, ".tar.zst")
+                ) {
+                    _ = try u.run_cmd(dpath, &.{"tar", "-xf", f, "-C", "."});
                 }
             },
         }
@@ -57,11 +62,11 @@ pub const DepType = enum {
         switch (self) {
             .system_lib, .framework => {},
             .git => {
-                _ = try u.run_cmd(dpath, &.{ "git", "fetch" });
-                _ = try u.run_cmd(dpath, &.{ "git", "pull" });
+                _ = try u.run_cmd(dpath, &.{"git", "fetch"});
+                _ = try u.run_cmd(dpath, &.{"git", "pull"});
             },
             .hg => {
-                _ = try u.run_cmd(dpath, &.{ "hg", "pull" });
+                _ = try u.run_cmd(dpath, &.{"hg", "pull"});
             },
             .http => {
                 //

--- a/src/util/module.zig
+++ b/src/util/module.zig
@@ -48,7 +48,7 @@ pub const Module = struct {
 
     pub fn get_hash(self: Module, cdpath: []const u8) ![]const u8 {
         const file_list_1 = &std.ArrayList([]const u8).init(gpa);
-        try u.file_list(try u.concat(&.{ cdpath, "/", self.clean_path }), file_list_1);
+        try u.file_list(try u.concat(&.{cdpath, "/", self.clean_path}), file_list_1);
 
         const file_list_2 = &std.ArrayList([]const u8).init(gpa);
         for (file_list_1.items) |item| {
@@ -66,10 +66,10 @@ pub const Module = struct {
 
         const h = &std.crypto.hash.Blake3.init(.{});
         for (file_list_2.items) |item| {
-            const abs_path = try u.concat(&.{ cdpath, "/", self.clean_path, "/", item });
+            const abs_path = try u.concat(&.{cdpath, "/", self.clean_path, "/", item});
             const file = try std.fs.cwd().openFile(abs_path, .{});
             defer file.close();
-            const input = try file.reader().readAllAlloc(gpa, u.mb * 100);
+            const input = try file.reader().readAllAlloc(gpa, u.mb*100);
             h.update(input);
         }
         var out: [32]u8 = undefined;

--- a/src/util/module.zig
+++ b/src/util/module.zig
@@ -10,6 +10,7 @@ const yaml = @import("./yaml.zig");
 
 pub const Module = struct {
     is_sys_lib: bool,
+    is_framework: bool,
     id: []const u8,
     name: []const u8,
     main: []const u8,
@@ -26,6 +27,7 @@ pub const Module = struct {
     pub fn from(dep: u.Dep) !Module {
         return Module{
             .is_sys_lib = false,
+            .is_framework = false,
             .id = dep.id,
             .name = dep.name,
             .main = dep.main,
@@ -46,7 +48,7 @@ pub const Module = struct {
 
     pub fn get_hash(self: Module, cdpath: []const u8) ![]const u8 {
         const file_list_1 = &std.ArrayList([]const u8).init(gpa);
-        try u.file_list(try u.concat(&.{cdpath, "/", self.clean_path}), file_list_1);
+        try u.file_list(try u.concat(&.{ cdpath, "/", self.clean_path }), file_list_1);
 
         const file_list_2 = &std.ArrayList([]const u8).init(gpa);
         for (file_list_1.items) |item| {
@@ -64,10 +66,10 @@ pub const Module = struct {
 
         const h = &std.crypto.hash.Blake3.init(.{});
         for (file_list_2.items) |item| {
-            const abs_path = try u.concat(&.{cdpath, "/", self.clean_path, "/", item});
+            const abs_path = try u.concat(&.{ cdpath, "/", self.clean_path, "/", item });
             const file = try std.fs.cwd().openFile(abs_path, .{});
             defer file.close();
-            const input = try file.reader().readAllAlloc(gpa, u.mb*100);
+            const input = try file.reader().readAllAlloc(gpa, u.mb * 100);
             h.update(input);
         }
         var out: [32]u8 = undefined;


### PR DESCRIPTION
Hi! I added (macOS) framework support for zigmod. From zig's perspective they basically function like regular system libraries, you just use `linkFramework` instead of `linkSystemLibrary`.

`LinkExeObjStep.linkFramework` currently `assert`s that the target OS is Darwin-based. This could be handled via `Dep`'s `only_os`, or hardcoded into the framework dependency type itself. This PR implements the former, simpler, version, but I'm open to implementing the latter if you think that it fits zigmod design better.

Please note that `zig fmt` changed a few lines that I otherwise did not touch. If that's a problem, I can undo it.