### PR TITLE
Use more fs functions from the std library

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -98,7 +98,7 @@ fn get_moddir(basedir: []const u8, d: u.Dep, parent_name: []const u8, comptime o
                     u.assert(false, "fetch: git: {s}: {s} {s} does not exist", .{d.path, @tagName(vers.id), vers.string});
                 }
                 const td_fd = try fs.cwd().openDir(basedir, .{});
-                try u.mkdir_all(pv);
+                try fs.cwd().makePath(pv);
                 try td_fd.rename("temp", try d.clean_path_v());
                 if (vers.id != .branch) {
                     const pvd = try std.fs.cwd().openDir(pv, .{});

--- a/src/util/dep.zig
+++ b/src/util/dep.zig
@@ -31,15 +31,15 @@ pub const Dep = struct {
         p = u.trim_prefix(p, "https://");
         p = u.trim_prefix(p, "git://");
         p = u.trim_suffix(u8, p, ".git");
-        p = try std.mem.join(gpa, "/", &.{@tagName(self.type), p});
+        p = try std.fs.path.join(gpa, &.{@tagName(self.type), p});
         return p;
     }
 
     pub fn clean_path_v(self: Dep) ![]const u8 {
         if (self.type == .http and self.version.len > 0) {
-            return std.mem.join(gpa, "/", &.{"v", @tagName(self.type), self.version[0..20]});
+            return std.fs.path.join(gpa, &.{"v", @tagName(self.type), self.version[0..20]});
         }
-        return std.mem.join(gpa, "/", &.{"v", try self.clean_path(), self.version});
+        return std.fs.path.join(gpa, &.{"v", try self.clean_path(), self.version});
     }
 
     pub fn is_for_this(self: Dep) bool {

--- a/src/util/dep_type.zig
+++ b/src/util/dep_type.zig
@@ -39,7 +39,7 @@ pub const DepType = enum {
                 _ = try u.run_cmd(null, &.{"hg", "clone", rpath, dpath});
             },
             .http => {
-                try u.mkdir_all(dpath);
+                try std.fs.cwd().makePath(dpath);
                 _ = try u.run_cmd(dpath, &.{"wget", rpath});
                 const f = rpath[std.mem.lastIndexOf(u8, rpath, "/").?+1..];
                 if (std.mem.endsWith(u8, f, ".zip")) {

--- a/src/util/funcs.zig
+++ b/src/util/funcs.zig
@@ -187,20 +187,6 @@ pub fn last(in: [][]const u8) ![]const u8 {
     return in[in.len - 1];
 }
 
-pub fn mkdir_all(dpath: []const u8) anyerror!void {
-    if (dpath.len == 0) {
-        return;
-    }
-    const d = if (dpath[dpath.len-1] == std.fs.path.sep) dpath[0..dpath.len-1] else dpath;
-    const ps = std.fs.path.sep_str;
-    if (std.mem.lastIndexOf(u8, d, ps)) |index| {
-        try mkdir_all(d[0..index]);
-    }
-    if (!try does_folder_exist(d)) {
-        try std.fs.cwd().makeDir(d);
-    }
-}
-
 pub fn rm_recv(path: []const u8) anyerror!void {
     const abs_path = std.fs.realpathAlloc(gpa, path) catch |e| switch (e) {
         error.FileNotFound => return,


### PR DESCRIPTION
Replaces mkdir_all with Dir.makePath which can handle mixed path separators on Windows.