### PR TITLE
cmd/fetch- use FileSource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git submodule update --init --recursive
 
       - run: apt -y install xz-utils jq
-      - run: ./download_zig.sh 0.8.0
+      - run: ./download_zig.sh 0.9.0-dev.133+ff79b87fa
       - run: zig version
       - run: zig env
       - run: zig build -Dbootstrap

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A package manager for the Zig programming language.
 - https://github.com/nektro/zigmod/releases
 
 ## Built With
-- Zig master `0.8.0`
+- Zig master `0.9.0-dev.133+ff79b87fa`
 
 ### Build from Source
 Initially,

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ You can learn more about Zig here:
 
 The rest of this documentation will assume you already have Zig installed.
 
-As Zig is still in development itself, if you plan to contribute to Zigmod you will need a master download of Zig. Those can be obtained from https://ziglang.org/download/#release-master. The most recent release Zigmod was verified to work with is `0.8.0`.
+As Zig is still in development itself, if you plan to contribute to Zigmod you will need a master download of Zig. Those can be obtained from https://ziglang.org/download/#release-master. The most recent release Zigmod was verified to work with is `0.9.0-dev.133+ff79b87fa`.
 
 ## Download
 You may download a precompiled binary from https://github.com/nektro/zigmod/releases or build the project from source.

--- a/src/cmd/fetch.zig
+++ b/src/cmd/fetch.zig
@@ -220,7 +220,7 @@ fn print_pkg_data_to(w: std.fs.File.Writer, notdone: *std.ArrayList(u.Module), d
     while (notdone.items.len > 0) {
         for (notdone.items) |mod, i| {
             if (contains_all(mod.deps, done.items)) {
-                try w.print("    pub const _{s} = std.build.Pkg{{ .name = \"{s}\", .path = cache ++ \"/{}/{s}\", .dependencies = &[_]std.build.Pkg{{", .{ mod.id[0..12], mod.name, std.zig.fmtEscapes(mod.clean_path), mod.main });
+                try w.print("    pub const _{s} = std.build.Pkg{{ .name = \"{s}\", .path = std.build.FileSource{{ .path = cache ++ \"/{}/{s}\" }}, .dependencies = &[_]std.build.Pkg{{", .{ mod.id[0..12], mod.name, std.zig.fmtEscapes(mod.clean_path), mod.main });
                 for (mod.deps) |d| {
                     if (d.main.len > 0) {
                         try w.print(" _{s},", .{d.id[0..12]});


### PR DESCRIPTION
https://github.com/ziglang/zig/pull/7959 got merged, so update `deps.zig` generation to account for it.

I planned to update the `deps.zig` file for zigmod itself, but looks like `aquila.red` is down. I validated the change works in a project of mine (ran `zigmod fetch && zig build` in it).