### PR TITLE
cmd/fetch- make it so lockfile generation contains the full commit hash

### DIFF
--- a/src/util/dep_type.zig
+++ b/src/util/dep_type.zig
@@ -80,7 +80,7 @@ pub const DepType = enum {
         return switch (self) {
             .local => "",
             .system_lib => "",
-            .git => try std.fmt.allocPrint(gpa, "commit-{s}", .{(try u.git_rev_HEAD(gpa, mdir))[0..7]}),
+            .git => try std.fmt.allocPrint(gpa, "commit-{s}", .{(try u.git_rev_HEAD(gpa, mdir))}),
             .hg => "",
             .http => "",
         };


### PR DESCRIPTION
Motivation: https://blog.teddykatz.com/2019/11/12/github-actions-dos.html