### PR TITLE
fix calls to mem.tokenize and mem.split

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git submodule update --init --recursive
 
       - run: apt -y install xz-utils jq
-      - run: ./download_zig.sh 0.9.0-dev.689+507dc1f2e
+      - run: ./download_zig.sh 0.9.0-dev.787+c53423f8a
       - run: zig version
       - run: zig env
       - run: zig build -Dbootstrap

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A package manager for the Zig programming language.
 - https://github.com/nektro/zigmod/releases
 
 ## Built With
-- Zig master `0.9.0-dev.689+507dc1f2e`
+- Zig master `0.9.0-dev.787+c53423f8a`
 - https://github.com/yaml/libyaml
 - https://github.com/nektro/zig-ansi
 - https://github.com/ziglibs/known-folders

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ The rest of this documentation will assume you already have Zig installed.
 
 As Zig is still in development itself, if you plan to contribute to Zigmod you will need a master download of Zig. Those can be obtained from https://ziglang.org/download/#release-master.
 
-The most recent release Zigmod was verified to work with is `0.9.0-dev.689+507dc1f2e`.
+The most recent release Zigmod was verified to work with is `0.9.0-dev.787+c53423f8a`.
 
 ## Download
 You may download a precompiled binary from https://github.com/nektro/zigmod/releases or build the project from source.

--- a/src/common.zig
+++ b/src/common.zig
@@ -349,7 +349,7 @@ pub fn parse_lockfile(path: []const u8) ![]const [4][]const u8 {
         }
         switch (v) {
             1 => {
-                var iter = std.mem.split(line, " ");
+                var iter = std.mem.split(u8, line, " ");
                 try list.append([4][]const u8{
                     iter.next().?,
                     iter.next().?,
@@ -358,7 +358,7 @@ pub fn parse_lockfile(path: []const u8) ![]const [4][]const u8 {
                 });
             },
             2 => {
-                var iter = std.mem.split(line, " ");
+                var iter = std.mem.split(u8, line, " ");
                 const asdep = u.Dep{
                     .type = std.meta.stringToEnum(u.DepType, iter.next().?).?,
                     .path = iter.next().?,

--- a/src/util/funcs.zig
+++ b/src/util/funcs.zig
@@ -35,7 +35,7 @@ pub fn try_index(comptime T: type, array: []T, n: usize, def: T) T {
 pub fn split(in: []const u8, delim: []const u8) ![][]const u8 {
     const list = &std.ArrayList([]const u8).init(gpa);
     defer list.deinit();
-    const iter = &std.mem.split(in, delim);
+    const iter = &std.mem.split(u8, in, delim);
     while (iter.next()) |str| {
         try list.append(str);
     }
@@ -214,7 +214,7 @@ pub fn parse_split(comptime T: type, delim: []const u8) type {
         string: []const u8,
 
         pub fn do(input: []const u8) !Self {
-            const iter = &std.mem.split(input, delim);
+            const iter = &std.mem.split(u8, input, delim);
             return Self{
                 .id = std.meta.stringToEnum(T, iter.next() orelse return error.IterEmpty) orelse return error.NoMemberFound,
                 .string = iter.rest(),

--- a/src/util/modfile.zig
+++ b/src/util/modfile.zig
@@ -79,7 +79,7 @@ pub const ModFile = struct {
                     var main = item.mapping.get_string("main");
 
                     if (item.mapping.get("src")) |val| {
-                        var src_iter = std.mem.tokenize(val.string, " ");
+                        var src_iter = std.mem.tokenize(u8, val.string, " ");
                         dtype = src_iter.next().?;
                         path = src_iter.next().?;
                         if (src_iter.next()) |dver| {


### PR DESCRIPTION
The API changed since https://github.com/ziglang/zig/commit/05fd20dc104b3654ce9c5d7a22a2bff66a940dba