### PR TITLE
Fix for Zig std.mem.Allocator changes

### DIFF
--- a/src/cmd/aq.zig
+++ b/src/cmd/aq.zig
@@ -20,7 +20,7 @@ pub const server_root = "https://aquila.red";
 
 pub fn execute(args: [][]u8) !void {
     if (args.len == 0) {
-        std.debug.warn("{s}\n", .{
+        std.log.warn("{s}\n", .{
             \\This is a subcommand for use with https://github.com/nektro/aquila instances but has no default behavior on its own aside from showing you this nice help text.
             \\
             \\The default remote is https://aquila.red.

--- a/src/cmd/zpm.zig
+++ b/src/cmd/zpm.zig
@@ -30,7 +30,7 @@ pub const Package = struct {
 
 pub fn execute(args: [][]u8) !void {
     if (args.len == 0) {
-        std.debug.warn("{s}\n", .{
+        std.log.warn("{s}\n", .{
             \\This is a subcommand for use with https://github.com/zigtools/zpm-server instances but has no default behavior on its own aside from showing you this nice help text.
             \\
             \\The default remote is https://zpm.random-projects.net/.

--- a/src/common.zig
+++ b/src/common.zig
@@ -19,7 +19,7 @@ pub const CollectOptions = struct {
     log: bool,
     update: bool,
     lock: ?[]const [4]string = null,
-    alloc: *std.mem.Allocator,
+    alloc: std.mem.Allocator,
     already_fetched: *std.ArrayList(string) = undefined,
 
     pub fn init(self: *CollectOptions) !void {
@@ -284,7 +284,7 @@ pub fn get_module_from_dep(d: *zigmod.Dep, cachepath: string, options: *CollectO
     }
 }
 
-pub fn add_files_package(alloc: *std.mem.Allocator, cachepath: string, pkg_name: string, mdir: std.fs.Dir, dirs: []const string) !zigmod.Module {
+pub fn add_files_package(alloc: std.mem.Allocator, cachepath: string, pkg_name: string, mdir: std.fs.Dir, dirs: []const string) !zigmod.Module {
     const fname = try std.mem.join(alloc, "", &.{ pkg_name, ".zig" });
 
     const map = &std.StringHashMap(string).init(alloc);
@@ -298,7 +298,7 @@ pub fn add_files_package(alloc: *std.mem.Allocator, cachepath: string, pkg_name:
             if (p.kind == .Directory) {
                 continue;
             }
-            const path = try std.mem.dupe(alloc, u8, p.path);
+            const path = try alloc.dupe(u8, p.path);
             try map.put(path, try std.fmt.allocPrint(alloc, "{s}/{s}", .{ dir_path, path }));
         }
     }
@@ -348,7 +348,7 @@ pub fn add_files_package(alloc: *std.mem.Allocator, cachepath: string, pkg_name:
     return (try get_module_from_dep(&d, filesdestpath, &options)).?;
 }
 
-pub fn parse_lockfile(alloc: *std.mem.Allocator, dir: std.fs.Dir) ![]const [4]string {
+pub fn parse_lockfile(alloc: std.mem.Allocator, dir: std.fs.Dir) ![]const [4]string {
     var list = std.ArrayList([4]string).init(alloc);
     const max = std.math.maxInt(usize);
     const f = try dir.openFile("zigmod.lock", .{});

--- a/src/util/dep.zig
+++ b/src/util/dep.zig
@@ -12,7 +12,7 @@ const yaml = @import("./yaml.zig");
 pub const Dep = struct {
     const Self = @This();
 
-    alloc: *std.mem.Allocator,
+    alloc: std.mem.Allocator,
     type: zigmod.DepType,
     path: string,
     id: string,

--- a/src/util/dep_type.zig
+++ b/src/util/dep_type.zig
@@ -32,7 +32,7 @@ pub const DepType = enum {
     // hypercore,  // https://hypercore-protocol.org/
 
     // zig fmt: on
-    pub fn pull(self: DepType, alloc: *std.mem.Allocator, rpath: string, dpath: string) !void {
+    pub fn pull(self: DepType, alloc: std.mem.Allocator, rpath: string, dpath: string) !void {
         switch (self) {
             .local => {},
             .system_lib => {},
@@ -57,7 +57,7 @@ pub const DepType = enum {
     }
 
     // zig fmt: on
-    pub fn update(self: DepType, alloc: *std.mem.Allocator, dpath: string, rpath: string) !void {
+    pub fn update(self: DepType, alloc: std.mem.Allocator, dpath: string, rpath: string) !void {
         _ = rpath;
 
         switch (self) {
@@ -77,7 +77,7 @@ pub const DepType = enum {
     }
 
     // zig fmt: on
-    pub fn exact_version(self: DepType, alloc: *std.mem.Allocator, mpath: string) !string {
+    pub fn exact_version(self: DepType, alloc: std.mem.Allocator, mpath: string) !string {
         var mdir = try std.fs.cwd().openDir(mpath, .{});
         defer mdir.close();
         return switch (self) {

--- a/src/util/funcs.zig
+++ b/src/util/funcs.zig
@@ -37,7 +37,7 @@ pub fn try_index(comptime T: type, array: []T, n: usize, def: T) T {
     return array[n];
 }
 
-pub fn split(alloc: *std.mem.Allocator, in: string, delim: string) ![]string {
+pub fn split(alloc: std.mem.Allocator, in: string, delim: string) ![]string {
     var list = std.ArrayList(string).init(alloc);
     defer list.deinit();
 
@@ -113,7 +113,7 @@ pub fn list_contains_gen(comptime T: type, haystack: []const T, needle: T) bool 
     return false;
 }
 
-pub fn file_list(alloc: *std.mem.Allocator, dpath: string) ![]const string {
+pub fn file_list(alloc: std.mem.Allocator, dpath: string) ![]const string {
     var list = std.ArrayList(string).init(alloc);
     defer list.deinit();
 
@@ -133,7 +133,7 @@ pub fn file_list(alloc: *std.mem.Allocator, dpath: string) ![]const string {
     return list.toOwnedSlice();
 }
 
-pub fn run_cmd_raw(alloc: *std.mem.Allocator, dir: ?string, args: []const string) !std.ChildProcess.ExecResult {
+pub fn run_cmd_raw(alloc: std.mem.Allocator, dir: ?string, args: []const string) !std.ChildProcess.ExecResult {
     return std.ChildProcess.exec(.{ .allocator = alloc, .cwd = dir, .argv = args, .max_output_bytes = std.math.maxInt(usize) }) catch |e| switch (e) {
         error.FileNotFound => {
             u.fail("\"{s}\" command not found", .{args[0]});
@@ -142,14 +142,14 @@ pub fn run_cmd_raw(alloc: *std.mem.Allocator, dir: ?string, args: []const string
     };
 }
 
-pub fn run_cmd(alloc: *std.mem.Allocator, dir: ?string, args: []const string) !u32 {
+pub fn run_cmd(alloc: std.mem.Allocator, dir: ?string, args: []const string) !u32 {
     const result = try run_cmd_raw(alloc, dir, args);
     alloc.free(result.stdout);
     alloc.free(result.stderr);
     return result.term.Exited;
 }
 
-pub fn list_remove(alloc: *std.mem.Allocator, input: []string, search: string) ![]string {
+pub fn list_remove(alloc: std.mem.Allocator, input: []string, search: string) ![]string {
     var list = std.ArrayList(string).init(alloc);
     defer list.deinit();
     for (input) |item| {
@@ -169,7 +169,7 @@ pub fn last(in: []string) !string {
 
 const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
 
-pub fn random_string(alloc: *std.mem.Allocator, len: usize) !string {
+pub fn random_string(alloc: std.mem.Allocator, len: usize) !string {
     const now = @intCast(u64, std.time.nanoTimestamp());
     var rand = std.rand.DefaultPrng.init(now);
     const r = &rand.random();
@@ -206,7 +206,7 @@ pub const HashFn = enum {
     sha512,
 };
 
-pub fn validate_hash(alloc: *std.mem.Allocator, input: string, file_path: string) !bool {
+pub fn validate_hash(alloc: std.mem.Allocator, input: string, file_path: string) !bool {
     const hash = parse_split(HashFn, "-").do(input) catch return false;
     const file = try std.fs.cwd().openFile(file_path, .{});
     defer file.close();
@@ -224,7 +224,7 @@ pub fn validate_hash(alloc: *std.mem.Allocator, input: string, file_path: string
     return result;
 }
 
-pub fn do_hash(alloc: *std.mem.Allocator, comptime algo: type, data: string) !string {
+pub fn do_hash(alloc: std.mem.Allocator, comptime algo: type, data: string) !string {
     const h = &algo.init(.{});
     var out: [algo.digest_length]u8 = undefined;
     h.update(data);
@@ -234,7 +234,7 @@ pub fn do_hash(alloc: *std.mem.Allocator, comptime algo: type, data: string) !st
 }
 
 /// Returns the result of running `git rev-parse HEAD`
-pub fn git_rev_HEAD(alloc: *std.mem.Allocator, dir: std.fs.Dir) !string {
+pub fn git_rev_HEAD(alloc: std.mem.Allocator, dir: std.fs.Dir) !string {
     const max = std.math.maxInt(usize);
     const dirg = try dir.openDir(".git", .{});
     const h = std.mem.trim(u8, try dirg.readFileAlloc(alloc, "HEAD", max), "\n");
@@ -248,7 +248,7 @@ pub fn slice(comptime T: type, input: []const T, from: usize, to: usize) []const
     return input[f..t];
 }
 
-pub fn detect_pkgname(alloc: *std.mem.Allocator, override: string, dir: string) !string {
+pub fn detect_pkgname(alloc: std.mem.Allocator, override: string, dir: string) !string {
     if (override.len > 0) {
         return override;
     }
@@ -264,7 +264,7 @@ pub fn detect_pkgname(alloc: *std.mem.Allocator, override: string, dir: string) 
     return name;
 }
 
-pub fn detct_mainfile(alloc: *std.mem.Allocator, override: string, dir: ?std.fs.Dir, name: string) !string {
+pub fn detct_mainfile(alloc: std.mem.Allocator, override: string, dir: ?std.fs.Dir, name: string) !string {
     if (override.len > 0) {
         if (try does_file_exist(dir, override)) {
             if (std.mem.endsWith(u8, override, ".zig")) {

--- a/src/util/modfile.zig
+++ b/src/util/modfile.zig
@@ -28,7 +28,7 @@ pub const ModFile = struct {
     rootdeps: []zigmod.Dep,
     builddeps: []zigmod.Dep,
 
-    pub fn init(alloc: *std.mem.Allocator, mpath: string) !Self {
+    pub fn init(alloc: std.mem.Allocator, mpath: string) !Self {
         const file = try std.fs.cwd().openFile(mpath, .{});
         defer file.close();
         const input = try file.reader().readAllAlloc(alloc, mb);
@@ -36,7 +36,7 @@ pub const ModFile = struct {
         return from_mapping(alloc, doc.mapping);
     }
 
-    pub fn from_dir(alloc: *std.mem.Allocator, dir: std.fs.Dir) !Self {
+    pub fn from_dir(alloc: std.mem.Allocator, dir: std.fs.Dir) !Self {
         const file = try dir.openFile("zig.mod", .{});
         defer file.close();
         const input = try file.reader().readAllAlloc(alloc, mb);
@@ -44,7 +44,7 @@ pub const ModFile = struct {
         return from_mapping(alloc, doc.mapping);
     }
 
-    pub fn from_mapping(alloc: *std.mem.Allocator, mapping: yaml.Mapping) !Self {
+    pub fn from_mapping(alloc: std.mem.Allocator, mapping: yaml.Mapping) !Self {
         const id = mapping.get_string("id");
         const name = mapping.get("name").?.string;
         const main = mapping.get_string("main");
@@ -69,7 +69,7 @@ pub const ModFile = struct {
         };
     }
 
-    fn dep_list_by_name(alloc: *std.mem.Allocator, mapping: yaml.Mapping, props: []const string, for_build: bool) anyerror![]zigmod.Dep {
+    fn dep_list_by_name(alloc: std.mem.Allocator, mapping: yaml.Mapping, props: []const string, for_build: bool) anyerror![]zigmod.Dep {
         var dep_list = std.ArrayList(zigmod.Dep).init(alloc);
         defer dep_list.deinit();
 

--- a/src/util/module.zig
+++ b/src/util/module.zig
@@ -11,7 +11,7 @@ const common = @import("./../common.zig");
 //
 
 pub const Module = struct {
-    alloc: *std.mem.Allocator,
+    alloc: std.mem.Allocator,
     is_sys_lib: bool,
     id: string,
     name: string,
@@ -27,7 +27,7 @@ pub const Module = struct {
     dep: ?zigmod.Dep,
     for_build: bool = false,
 
-    pub fn from(alloc: *std.mem.Allocator, dep: zigmod.Dep, modpath: string, options: *common.CollectOptions) !Module {
+    pub fn from(alloc: std.mem.Allocator, dep: zigmod.Dep, modpath: string, options: *common.CollectOptions) !Module {
         var moddeps = std.ArrayList(Module).init(alloc);
         defer moddeps.deinit();
 

--- a/src/util/yaml.zig
+++ b/src/util/yaml.zig
@@ -110,7 +110,7 @@ pub const Mapping = struct {
         return if (self.get(k)) |v| v.string else "";
     }
 
-    pub fn get_string_array(self: Mapping, alloc: *std.mem.Allocator, k: string) ![]string {
+    pub fn get_string_array(self: Mapping, alloc: std.mem.Allocator, k: string) ![]string {
         var list = std.ArrayList(string).init(alloc);
         defer list.deinit();
         if (self.get(k)) |val| {
@@ -145,7 +145,7 @@ pub const TokenList = []const Token;
 //
 //
 
-pub fn parse(alloc: *std.mem.Allocator, input: string) !Document {
+pub fn parse(alloc: std.mem.Allocator, input: string) !Document {
     var parser: c.yaml_parser_t = undefined;
     _ = c.yaml_parser_initialize(&parser);
     defer c.yaml_parser_delete(&parser);
@@ -182,7 +182,7 @@ pub fn parse(alloc: *std.mem.Allocator, input: string) !Document {
 }
 
 pub const Parser = struct {
-    alloc: *std.mem.Allocator,
+    alloc: std.mem.Allocator,
     tokens: TokenList,
     lines: []const string,
     index: usize,


### PR DESCRIPTION
Fix for allocgate https://pithlessly.github.io/allocgate.html

I also had to change `std.debug.warn` to `std.log.warn` to fix some deprecation errors.