### PR TITLE
fix aquila command not using updated ChildProcess

### DIFF
--- a/src/cmd/aquila/install.zig
+++ b/src/cmd/aquila/install.zig
@@ -67,7 +67,7 @@ pub fn execute(args: [][]u8) !void {
         "--prefix",    try std.fs.path.join(gpa, &.{ homepath, ".zigmod" }),
         "--cache-dir", try std.fs.path.join(gpa, &.{ cache.?, "zigmod", "zig" }),
     };
-    const proc = try std.ChildProcess.init(argv, gpa);
+    var proc = std.ChildProcess.init(argv, gpa);
     proc.cwd = modpath;
     const term = try proc.spawnAndWait();
     switch (term) {

--- a/src/cmd/aquila/update.zig
+++ b/src/cmd/aquila/update.zig
@@ -53,7 +53,7 @@ pub fn execute(args: [][]u8) !void {
             "--prefix",    try std.fs.path.join(gpa, &.{ homepath, ".zigmod" }),
             "--cache-dir", try std.fs.path.join(gpa, &.{ cache.?, "zigmod", "zig" }),
         };
-        const proc = try std.ChildProcess.init(argv, gpa);
+        var proc = std.ChildProcess.init(argv, gpa);
         proc.cwd = modpath;
         const term = try proc.spawnAndWait();
         switch (term) {


### PR DESCRIPTION
Updates `src/cmd/aquila` to use the updated `ChildProcess` implementation.