### PR TITLE
expected error Union type, fix for 'std.child_process.ChildProcess' found

### DIFF
--- a/src/cmd/aquila/install.zig
+++ b/src/cmd/aquila/install.zig
@@ -67,7 +67,7 @@ pub fn execute(args: [][]u8) !void {
         "--prefix",    try std.fs.path.join(gpa, &.{ homepath, ".zigmod" }),
         "--cache-dir", try std.fs.path.join(gpa, &.{ cache.?, "zigmod", "zig" }),
     };
-    const proc = try std.ChildProcess.init(argv, gpa);
+    var proc = std.ChildProcess.init(argv, gpa);
     proc.cwd = modpath;
     const term = try proc.spawnAndWait();
     switch (term) {

--- a/src/cmd/aquila/update.zig
+++ b/src/cmd/aquila/update.zig
@@ -53,7 +53,7 @@ pub fn execute(args: [][]u8) !void {
             "--prefix",    try std.fs.path.join(gpa, &.{ homepath, ".zigmod" }),
             "--cache-dir", try std.fs.path.join(gpa, &.{ cache.?, "zigmod", "zig" }),
         };
-        const proc = try std.ChildProcess.init(argv, gpa);
+        var proc = std.ChildProcess.init(argv, gpa);
         proc.cwd = modpath;
         const term = try proc.spawnAndWait();
         switch (term) {


### PR DESCRIPTION
## What
I get an error like this. update.zig & install.zig
```
error: expected error union type, found 'std.child_process.ChildProcess'
        var proc = try std.ChildProcess.init(argv, gpa);
```


## Enviroment
my zig version => `0.10.0-dev.2340+1a92264b3`
os env => `aarch64`
zigmod version => `zigmod dev-1deedb26f macos aarch64 gnu`