### PR TITLE
update for openIterableDir in Zig

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: "0.10.0-dev.2802+54454fd01"
+          version: "0.10.0-dev.3027+0e26c6149"
 
       - run: zig version
       - run: zig env

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: "0.10.0-dev.2802+54454fd01"
+          version: "0.10.0-dev.3027+0e26c6149"
 
       - run: zig version
       - run: zig env

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A package manager for the Zig programming language.
 - https://github.com/nektro/zigmod/releases
 
 ## Built With
-- Zig master (at least `0.10.0-dev.2802+54454fd01`)
+- Zig master (at least `0.10.0-dev.3027+0e26c6149`)
 - See [`zig.mod`](./zig.mod) and [`zigmod.lock`](./zigmod.lock)
 
 ### Build from Source

--- a/deps.zig
+++ b/deps.zig
@@ -51,7 +51,7 @@ pub const Package = struct {
 };
 
 fn checkMinZig(current: std.SemanticVersion, exe: *std.build.LibExeObjStep) void {
-    const min = std.SemanticVersion.parse("0.10.0-dev.2802+54454fd01") catch return;
+    const min = std.SemanticVersion.parse("0.10.0-dev.3027+0e26c6149") catch return;
     if (current.order(min).compare(.lt)) @panic(exe.builder.fmt("Your Zig version v{} does not meet the minimum build requirement of v{}", .{current, min}));
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ The rest of this documentation will assume you already have Zig installed.
 
 As Zig is still in development itself, if you plan to contribute to Zigmod you will need a master download of Zig. Those can be obtained from https://ziglang.org/download/#release-master.
 
-The earliest Zig release this Zigmod was verified to work with is `0.10.0-dev.2802+54454fd01`.
+The earliest Zig release this Zigmod was verified to work with is `0.10.0-dev.3027+0e26c6149`.
 
 ## Download
 You may download a precompiled binary from https://github.com/nektro/zigmod/releases or build the project from source.

--- a/src/cmd/fetch.zig
+++ b/src/cmd/fetch.zig
@@ -102,7 +102,7 @@ pub fn create_depszig(alloc: std.mem.Allocator, cachepath: string, dir: std.fs.D
 
     try w.print(
         \\fn checkMinZig(current: std.SemanticVersion, exe: *std.build.LibExeObjStep) void {{
-        \\    const min = std.SemanticVersion.parse("{}") catch return;
+        \\    const min = std.SemanticVersion.parse("{?}") catch return;
         \\    if (current.order(min).compare(.lt)) @panic(exe.builder.fmt("Your Zig version v{{}} does not meet the minimum build requirement of v{{}}", .{{current, min}}));
         \\}}
         \\

--- a/src/common.zig
+++ b/src/common.zig
@@ -299,7 +299,7 @@ pub fn add_files_package(alloc: std.mem.Allocator, cachepath: string, pkg_name: 
     defer map.deinit();
 
     for (dirs) |dir_path| {
-        const dir = try mdir.openDir(dir_path, .{ .iterate = true });
+        const dir = try mdir.openIterableDir(dir_path, .{});
         var walker = try dir.walk(alloc);
         defer walker.deinit();
         while (try walker.next()) |p| {

--- a/src/util/funcs.zig
+++ b/src/util/funcs.zig
@@ -113,7 +113,7 @@ pub fn file_list(alloc: std.mem.Allocator, dpath: string) ![]const string {
     var list = std.ArrayList(string).init(alloc);
     defer list.deinit();
 
-    const dir = try std.fs.cwd().openDir(dpath, .{ .iterate = true });
+    const dir = try std.fs.cwd().openIterableDir(dpath, .{});
     var walk = try dir.walk(alloc);
     defer walk.deinit();
     while (true) {

--- a/zig.mod
+++ b/zig.mod
@@ -3,7 +3,7 @@ name: zigmod
 main: src/lib.zig
 license: MIT
 description: A package manager for the Zig programming language.
-min_zig_version: 0.10.0-dev.2802+54454fd01
+min_zig_version: 0.10.0-dev.3027+0e26c6149
 dependencies:
   - src: git https://github.com/yaml/libyaml tag-0.2.5
     id: 8mdbh0zuneb0i3hs5jby5je0heem1i6yxusl7c8y8qx68hqc


### PR DESCRIPTION
Hi,
fix to be compatible with zig version "0.10.0-dev.3027+0e26c6149" ("master" binaries currently available on https://ziglang.org/download/ ) + updates for CI.

same fix as https://github.com/zigtools/zls/pull/544