### PR TITLE
Update to fs module fn `openIterableDir`

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -299,7 +299,7 @@ pub fn add_files_package(alloc: std.mem.Allocator, cachepath: string, pkg_name: 
     defer map.deinit();
 
     for (dirs) |dir_path| {
-        const dir = try mdir.openDir(dir_path, .{ .iterate = true });
+        const dir = try mdir.openIterableDir(dir_path, .{});
         var walker = try dir.walk(alloc);
         defer walker.deinit();
         while (try walker.next()) |p| {

--- a/src/util/funcs.zig
+++ b/src/util/funcs.zig
@@ -113,7 +113,7 @@ pub fn file_list(alloc: std.mem.Allocator, dpath: string) ![]const string {
     var list = std.ArrayList(string).init(alloc);
     defer list.deinit();
 
-    const dir = try std.fs.cwd().openDir(dpath, .{ .iterate = true });
+    const dir = try std.fs.cwd().openIterableDir(dpath, .{});
     var walk = try dir.walk(alloc);
     defer walk.deinit();
     while (true) {


### PR DESCRIPTION
Commit
https://github.com/ziglang/zig/commit/262f4c7b3a850594a75ec154db2ba8d5f9f517ab
removed the `iterable` option in the Dir options provided to `openDir`
and replaced it with a `openIterableDir` fn taking a path and an options
config.
This commit updates to use the new API for creating an iterable Dir
object from a path