### PR TITLE
Add nix flake build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670538458,
+        "narHash": "sha256-mvKmBkdlhzsMBtnzYXjYn08EGw9rFBEE9hp4Uqgol1Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "99ec06122f481588abafd91f2710d80a5320efe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1661151577,
+        "narHash": "sha256-++S0TuJtuz9IpqP8rKktWyHZKpgdyrzDFUXVY07MTRI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54060e816971276da05970a983487a25810c38a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils",
+        "zig": "zig"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1670545432,
+        "narHash": "sha256-aVdVhuFm/J45W8K887/vIvKzJPLnhiBkIJMlbWBLgWA=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "0e3e713a8ba413d9b1268a9dba52420435aa6e6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -55,12 +55,28 @@
           description = "zigmod";
         };
       };
+
     in rec {
-      packages = {
-        demo = demo;
-        default = demo;
+      # packages = {
+      #   demo = demo;
+      #   default = demo;
+      # };
+
+      defaultPackage = pkgs.zigpkgs.master;
+
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [
+          zigpkgs.master
+        ];
+
+        buildInputs = [
+          git
+          mercurial
+          wget
+          unzip
+          gnutar
+        ];
       };
 
-      defaultPackage = demo;
-    });
+      devShell = self.devShells.${system}.default;    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,10 @@
       pname = "zigmod";
       version = "0.1.0";
 
-      demo = pkgs.stdenv.mkDerivation {
+      zigVersion = "master";
+      z = pkgs.zigpkgs.${zigVersion};
+
+      zigmod = pkgs.stdenv.mkDerivation {
         inherit pname version;
         src = ./.;
         nativeBuildInputs = with pkgs; [
@@ -33,7 +36,7 @@
           wget
           unzip
           gnutar
-          zigpkgs.master
+          z
           pkg-config
         ];
         buildInputs = with pkgs; [ ];
@@ -44,25 +47,27 @@
 
         installPhase = ''
           runHook preInstall
-          zig build
+          zig build --prefix $out install
           runHook postInstall
         '';
 
         installFlags = ["DESTDIR=$(out)"];
 
-        meta = {
-          maintainers = [ "Jake Chvatal <jake@isnt.online>" ];
-          description = "zigmod";
+        meta = with pkgs.lib; {
+          description = "A package manager for the Zig programming language.";
+          license = licenses.mit;
+          platforms = platforms.linux;
+          maintainers = with maintainers; [ jakeisnt ];
         };
       };
 
     in rec {
-      # packages = {
-      #   demo = demo;
-      #   default = demo;
-      # };
+      packages = {
+        zigmod = zigmod;
+        default = zigmod;
+      };
 
-      defaultPackage = pkgs.zigpkgs.master;
+      defaultPackage = zigmod;
 
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,15 @@
       demo = pkgs.stdenv.mkDerivation {
         inherit pname version;
         src = ./.;
-        nativeBuildInputs = with pkgs; [ zigpkgs.master pkg-config ];
+        nativeBuildInputs = with pkgs; [
+          git
+          mercurial
+          wget
+          unzip
+          gnutar
+          zigpkgs.master
+          pkg-config
+        ];
         buildInputs = with pkgs; [ ];
         dontConfigure = true;
         preBuild = ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  inputs = {
+    # zicross.url = github:flyx/Zicross;
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
+    zig.url     = github:mitchellh/zig-overlay;
+    utils.url   = github:numtide/flake-utils;
+  };
+
+  outputs = {self, nixpkgs, zig, utils}: with utils.lib;
+    eachSystem allSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [zig.overlays.default];
+      };
+
+      pname = "zigmod";
+      version = "0.1.0";
+      demo = pkgs.stdenv.mkDerivation {
+        inherit pname version;
+        src = ./.;
+        nativeBuildInputs = [ pkgs.zig pkgs.pkg-config ];
+        buildInputs = with pkgs; [ ];
+        dontConfigure = true;
+        preBuild = ''
+          export HOME=$TMPDIR
+        '';
+
+        installPhase = ''
+          runHook preInstall
+          zig build
+          runHook postInstall
+        '';
+
+        installFlags = ["DESTDIR=$(out)"];
+
+        meta = {
+          maintainers = [ "Jake Chvatal <jake@isnt.online>" ];
+          description = "zigmod";
+        };
+      };
+    in rec {
+      packages = {
+        demo = demo;
+        default = demo;
+      };
+
+      defaultPackage = demo;
+    });
+}


### PR DESCRIPTION
To more easily incorporate this in a package build process, would love to be able to build it off of - and expose it to - a flake.

This flake doesn't work currently, because flakes can't fetch information from the internet; the flake refuses to resolve `github.com` during the build process.

Any help here would be appreciated.