### PR TITLE
build: add `-Doptimize` options

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,9 @@ const deps = @import("./deps.zig");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
-    const mode = b.option(std.builtin.Mode, "mode", "") orelse .Debug;
+    const mode = b.option(std.builtin.Mode, "mode", "");
+    const optimize = b.standardOptimizeOption(.{});
+    const optimization_mode = mode orelse optimize;
     const use_full_name = b.option(bool, "use-full-name", "") orelse false;
     const with_arch_os = b.fmt("-{s}-{s}", .{ @tagName(target.result.cpu.arch), @tagName(target.result.os.tag) });
     const exe_name = b.fmt("{s}{s}", .{ "zigmod", if (use_full_name) with_arch_os else "" });
@@ -13,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .name = exe_name,
         .root_source_file = b.path("src/main.zig"),
         .target = target,
-        .optimize = mode,
+        .optimize = optimization_mode,
     });
     const tag = b.option(string, "tag", "") orelse "dev";
     const strip = b.option(bool, "strip", "Build without debug info.") orelse false;


### PR DESCRIPTION
I am not very familiar with Zig and its build system but it seems like `-Doptimize` is intended to be a "standard" flag for compilation mode. Maybe it can be used if `-Dmode` is not set